### PR TITLE
fix: not getting root path when installed using pnpm node package manager

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
-module.exports = require('../../.eslintplugin')
+const Path = require('path')
+const appRoot = Path.resolve(__dirname).split('/node_modules')[0]
+module.exports = require(appRoot + '/.eslintplugin')


### PR DESCRIPTION
Issue: PNPM node package manager uses a different `node_module` file structure than `yarn` or `npm` which caused issue in getting to root path by `../..`

This PR will take another approach to get the root dir.