### PR TITLE
fix: breaking changes in testRunner from ESLint v9

### DIFF
--- a/testRunner.js
+++ b/testRunner.js
@@ -34,7 +34,10 @@ function testRunner(
 	{ bail, log, err } = { bail: false, log: console.log, err: console.error }
 ) {
 	// See https://eslint.org/docs/latest/integrate/nodejs-api#ruletester
-	const tester = new RuleTester()
+	const tester = new RuleTester({ parserOptions: {
+		ecmaVersion: 'latest',
+		sourceType: 'module',
+	  }})
 
 	const oneOrMoreTestCaseIsSkipped = Object.values(rules).some(ruleModule =>
 		ruleModule.tests?.valid?.some(testCase => testCase[Exclusiveness]) ||


### PR DESCRIPTION
As of eslint v9 they are by default setting `ecmaVersion: 'latest', sourceType: 'module'` in `RuleTester` when no `parserOptions` are provided (per note on <https://eslint.org/docs/latest/integrate/nodejs-api#ruletester>).

However, prior to v8 it does not do this. This leads to issues with tests for example, not being able to use async/await.

I've published a [temporary npm package](https://www.npmjs.com/package/ryan0x44-eslint-plugin-local) with this change to verify it:

```
bun install -d eslint-plugin-local@npm:ryan0x44-eslint-plugin-local
```